### PR TITLE
enable 'kagiana client' to get token value by env KAGIANA_TOKEN

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -59,6 +59,11 @@ var token string
 var savePath string
 
 func runClient() error {
+
+	if token == "" {
+		token = viper.GetString("token")
+	}
+
 	opt := &libstns.Options{
 		PrivatekeyPath:     keyPath,
 		PrivatekeyPassword: keyPass,
@@ -197,6 +202,9 @@ func verify(endpoint, authType, token, signature, userName, savePath, code strin
 
 func init() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvPrefix("kagiana")
+	viper.BindEnv("token")
+
 	clientCmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "e", "", "Kagiana Endpoint")
 	clientCmd.PersistentFlags().StringVarP(&authType, "auth-type", "a", "stns", "Authentication type")
 	clientCmd.PersistentFlags().StringVarP(&userName, "user", "u", "", "Authentication User")
@@ -208,7 +216,6 @@ func init() {
 
 	clientCmd.MarkPersistentFlagRequired("endpoint")
 	clientCmd.MarkPersistentFlagRequired("user")
-	clientCmd.MarkPersistentFlagRequired("token")
 
 	rootCmd.AddCommand(clientCmd)
 }


### PR DESCRIPTION
Hi @pyama86 さん

This PR to allow the environment variable KAGIANA_TOKEN to be passed as a token instead of `-t` in the kagiana client. 
Exposure and use of the token on the command line may risk leakage

> kagiana client の `-t` の代わりに 環境変数 KAGIANA_TOKEN でも token を渡せるようにする PR です
> token をコマンドラインで露出して使うと漏洩のリスクがあります


```
  -t, --token string                 Authentication Token
```

## Sample USAGE

```
$ export KAGIANA_TOKEN=****
$ kagiana client -e https://kagiana.example.com -u hiboma
```